### PR TITLE
abort build process if already up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - '8'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "electron-releases",
   "description": "Complete and up-to-date info about every release of Electron",
+  "repository": "https://github.com/electron/electron-releases",
   "version": "1.1.0",
   "main": "index.json",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ This package:
 - includes V8, Chromium, and Node.js version data.
 - includes [GitHub-flavored HTML](https://ghub.io/hubdown) for each release's changelog.
 - ignores npm versions from the days before [Electron was `electron`](https://electronjs.org/blog/npm-install-electron).
-- is updated daily.
+- is [updated regularly](#updates).
 
 ## Installation
 
@@ -44,8 +44,8 @@ Each release contains all the data returned by the
 plus some extra properties:
 
 - `version` (String) - the same thing as `dist_tag`, but without the `v` for convenient [semver comparisons](https://github.com/npm/node-semver#usage).
-- `npmDistTag` (String) - an [npm dist-tag](https://docs.npmjs.com/cli/dist-tag) like `latest` or `beta`. Most releases will not have a dist tag.
-- `npmPackageName` (String) - For packages published to npm, this will be `electron` or `electron-prebuilt`
+- `npmDistTag` (String) - an [npm dist-tag](https://docs.npmjs.com/cli/dist-tag) like `latest` or `beta`. Most releases will not have this property.
+- `npmPackageName` (String) - For packages published to npm, this will be `electron` or `electron-prebuilt`. For packages not published to npm, this property will not exist.
 - `totalDownloads` (Number) - Total downloads of all assets in the release that 
   have a [detectable platform](https://github.com/zeke/platform-utils#api) in their
   filename like `.zip`, `.dmg`, `.exe`, `.rpm`, `.deb`, etc.
@@ -54,6 +54,21 @@ plus some extra properties:
   - `chromium` (String)
   - `node` (String)
   - etc..
+
+## Updates
+
+This module is self-publishing. It runs in a 
+[Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) 
+process every ten minutes. A new version of this module is published if any of 
+the following change:
+
+- number of Electron releases on GitHub
+- number of Electron releases on npm
+- npm `electron@beta` version
+- npm `electron@latest` version
+
+If none of these has changed, the build process aborts and runs again ten minutes
+later. For more detail, see [script/release.sh](script/release.sh)
 
 ## Tests
 


### PR DESCRIPTION
This will prevent rampant publishes from the Heroku scheduled task, which will be running this every ten minutes.