### PR TITLE
Use snake_case for all exported properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "chai": "^4.1.2",
     "check-for-leaks": "^1.2.0",
     "dotenv-safe": "^4.0.4",
+    "flat": "^4.0.0",
     "github": "^13.0.1",
     "got": "^8.0.1",
     "hubdown": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron-releases",
   "description": "Complete and up-to-date info about every release of Electron",
   "repository": "https://github.com/electron/electron-releases",
-  "version": "1.13.0",
+  "version": "2.0.0",
   "main": "index.json",
   "license": "MIT",
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -31,10 +31,10 @@ const releases = require('electron-releases')
 releases[0].tag_name // => 'v1.8.2-beta.3'
 
 // find `latest` on npm, which is not necessarily the most recent release:
-releases.find(release => release.npmDistTag === 'latest')
+releases.find(release => release.npm_dist_tag === 'latest')
 
 // find `beta` on npm:
-releases.find(release => release.npmDistTag === 'beta')
+releases.find(release => release.npm_dist_tag === 'beta')
 ```
 
 ### Data
@@ -44,12 +44,12 @@ Each release contains all the data returned by the
 plus some extra properties:
 
 - `version` (String) - the same thing as `dist_tag`, but without the `v` for convenient [semver comparisons](https://github.com/npm/node-semver#usage).
-- `npmDistTag` (String) - an [npm dist-tag](https://docs.npmjs.com/cli/dist-tag) like `latest` or `beta`. Most releases will not have this property.
-- `npmPackageName` (String) - For packages published to npm, this will be `electron` or `electron-prebuilt`. For packages not published to npm, this property will not exist.
-- `totalDownloads` (Number) - Total downloads of all assets in the release that 
+- `npm_dist_tag` (String) - an [npm dist-tag](https://docs.npmjs.com/cli/dist-tag) like `latest` or `beta`. Most releases will not have this property.
+- `npm_package_name` (String) - For packages published to npm, this will be `electron` or `electron-prebuilt`. For packages not published to npm, this property will not exist.
+- `total_downloads` (Number) - Total downloads of all assets in the release that 
   have a [detectable platform](https://github.com/zeke/platform-utils#api) in their
   filename like `.zip`, `.dmg`, `.exe`, `.rpm`, `.deb`, etc.
-- `dependencyVersions` (Object) - version numbers for Electron dependencies.
+- `deps` (Object) - version numbers for Electron dependencies.
   - `v8` (String)
   - `chromium` (String)
   - `node` (String)

--- a/script/build.js
+++ b/script/build.js
@@ -81,19 +81,19 @@ async function main () {
     release.version = release.tag_name.substring(1)
 
     // published to npm? electron? electron-prebuilt?
-    if (npmVersions.includes(release.version)) release.npmPackageName = 'electron'
-    if (npmVersionsPrebuilt.includes(release.version)) release.npmPackageName = 'electron-prebuilt'
+    if (npmVersions.includes(release.version)) release.npm_package_name = 'electron'
+    if (npmVersionsPrebuilt.includes(release.version)) release.npm_package_name = 'electron-prebuilt'
 
     // weave in version data for V8, Chromium, Node.js, etc
     const deps = depData.find(version => version.version === release.version)
-    if (deps) release.dependencyVersions = deps
+    if (deps) release.deps = deps
 
     // apply dist tags from npm (usually `latest` and `beta`)
     const npmDistTag = npmDistTaggedVersions[release.version]
-    if (npmDistTag) release.npmDistTag = npmDistTag
+    if (npmDistTag) release.npm_dist_tag = npmDistTag
 
     if (release.assets) {
-      release.totalDownloads = release.assets
+      release.total_downloads = release.assets
         .reduce((acc, asset) => {
           const platform = getPlatformFromFilename(asset.name)
           if (platform) acc += asset.download_count
@@ -110,21 +110,20 @@ async function main () {
   console.log('processing changelogs to HTML')
   releases = await Promise.all(releases.map(processRelease))
 
-
   // Abort the build early if module is already up to date
   const old = require('..')
-  const oldLatest = old.find(release => release.npmDistTag === 'latest').version
-  const newLatest = releases.find(release => release.npmDistTag === 'latest').version
-  const oldBeta = old.find(release => release.npmDistTag === 'beta').version
-  const newBeta = releases.find(release => release.npmDistTag === 'beta').version
-  const oldNpmCount = old.find(release => release.npmPackageName === 'electron').length
-  const newNpmCount = releases.find(release => release.npmPackageName === 'electron').length
+  const oldLatest = old.find(release => release.npm_dist_tag === 'latest').version
+  const newLatest = releases.find(release => release.npm_dist_tag === 'latest').version
+  const oldBeta = old.find(release => release.npm_dist_tag === 'beta').version
+  const newBeta = releases.find(release => release.npm_dist_tag === 'beta').version
+  const oldNpmCount = old.find(release => release.npm_package_name === 'electron').length
+  const newNpmCount = releases.find(release => release.npm_package_name === 'electron').length
 
   if (
-    old.length === releases.length
-    && oldLatest === newLatest
-    && oldBeta === newBeta
-    && oldNpmCount === newNpmCount
+    old.length === releases.length &&
+    oldLatest === newLatest &&
+    oldBeta === newBeta &&
+    oldNpmCount === newNpmCount
   ) {
     console.log('module already has up-to-date versions and dist tags. exiting.')
     process.exit()

--- a/test/index.js
+++ b/test/index.js
@@ -36,38 +36,38 @@ describe('electron-releases', () => {
   })
 
   it('includes version data for V8, Chromium, Node.js, etc', () => {
-    const releasesWithVersionData = releases.filter(release => release.dependencyVersions)
+    const releasesWithVersionData = releases.filter(release => release.deps)
     releasesWithVersionData.length.should.be.above(154)
   })
 
   it('includes one release with the `beta` npm dist tag', () => {
-    const betas = releases.filter(release => release.npmDistTag === 'beta')
+    const betas = releases.filter(release => release.npm_dist_tag === 'beta')
     betas.length.should.eq(1)
   })
 
   it('includes one release with the `latest` npm dist tag', () => {
-    const latests = releases.filter(release => release.npmDistTag === 'latest')
+    const latests = releases.filter(release => release.npm_dist_tag === 'latest')
     latests.length.should.eq(1)
   })
 
-  it('includes npmPackageName prop to indicate npm publish status', () => {
-    releases.find(release => release.version === '1.4.7').npmPackageName.should.eq('electron')
-    releases.find(release => release.version === '1.0.0').npmPackageName.should.eq('electron-prebuilt')
-    releases.filter(release => release.npmPackageName === 'electron').length.should.be.above(62)
+  it('includes npm_package_name prop to indicate npm publish status', () => {
+    releases.find(release => release.version === '1.4.7').npm_package_name.should.eq('electron')
+    releases.find(release => release.version === '1.0.0').npm_package_name.should.eq('electron-prebuilt')
+    releases.filter(release => release.npm_package_name === 'electron').length.should.be.above(62)
 
     // assert exact number because the days of publishing electron-prebuilt are over
-    releases.filter(release => release.npmPackageName === 'electron-prebuilt').length.should.eq(96)
+    releases.filter(release => release.npm_package_name === 'electron-prebuilt').length.should.eq(96)
   })
 
   // for context, see https://electronjs.org/blog/npm-install-electron
-  it('sets `electron` as `npmPackageName` for releases >=1.3.1', () => {
-    const npmReleasesOfElectron = releases.filter(release => release.npmPackageName === 'electron')
+  it('sets `electron` as `npm_package_name` for releases >=1.3.1', () => {
+    const npmReleasesOfElectron = releases.filter(release => release.npm_package_name === 'electron')
     npmReleasesOfElectron.length.should.be.above(0)
     npmReleasesOfElectron.every(release => semver.gte(release.version, '1.3.1')).should.eq(true)
   })
 
-  it('sets `electron-prebuilt` as `npmPackageName` for releases <1.3.1', () => {
-    const npmReleasesOfElectronPrebuilt = releases.filter(release => release.npmPackageName === 'electron-prebuilt')
+  it('sets `electron-prebuilt` as `npm_package_name` for releases <1.3.1', () => {
+    const npmReleasesOfElectronPrebuilt = releases.filter(release => release.npm_package_name === 'electron-prebuilt')
     npmReleasesOfElectronPrebuilt.length.should.be.above(0)
     npmReleasesOfElectronPrebuilt.every(release => semver.lt(release.version, '1.3.1')).should.eq(true)
   })
@@ -75,9 +75,9 @@ describe('electron-releases', () => {
   it('includes processed changelogs in HTML format')//, () => {
   // })
 
-  it('includes a totalDownloads property for each release', () => {
-    const npmReleases = releases.filter(release => release.npmPackageName)
+  it('includes a total_downloads property for each release', () => {
+    const npmReleases = releases.filter(release => release.npm_package_name)
     npmReleases.length.should.be.above(0)
-    npmReleases.every(release => release.totalDownloads > 0).should.eq(true)
+    npmReleases.every(release => release.total_downloads > 0).should.eq(true)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@ require('chai').should()
 const {describe, it} = require('mocha')
 const releases = require('..')
 const semver = require('semver')
+const flat = require('flat')
 
 describe('electron-releases', () => {
   it('is an array', () => {
@@ -10,6 +11,12 @@ describe('electron-releases', () => {
 
   it('contains over 270 releases', () => {
     releases.length.should.be.above(270)
+  })
+
+  it('uses snake_case for all properties', () => {
+    const keys = Object.keys(flat(releases))
+    keys.length.should.be.above(0)
+    keys.every(key => key.toLowerCase() === key).should.eq(true)
   })
 
   it('sets `tag_name` on every release', () => {


### PR DESCRIPTION
Fixes #3. Manually included a major version bump to prevent the Heroku release bot from publishing a minor instead.