### PR TITLE
test that all recent releases have v8/node/chrome dependency data

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -87,4 +87,18 @@ describe('electron-releases', () => {
     npmReleases.length.should.be.above(0)
     npmReleases.every(release => release.total_downloads > 0).should.eq(true)
   })
+
+  it('includes chrome, node, and v8 versions for all recent releases', () => {
+    const recentReleases = releases.filter(release => semver.gte(release.version, '1.8.0'))
+    recentReleases.length.should.be.above(5)
+    console.log(recentReleases.map(r => {
+      return {version: r.version, deps: r.deps}
+    }))
+    recentReleases.every(release => {
+      return release.deps &&
+      release.deps.node.length &&
+      release.deps.chrome.length &&
+      release.deps.v8.length
+    }).should.eq(true)
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -91,9 +91,6 @@ describe('electron-releases', () => {
   it('includes chrome, node, and v8 versions for all recent releases', () => {
     const recentReleases = releases.filter(release => semver.gte(release.version, '1.8.0'))
     recentReleases.length.should.be.above(5)
-    console.log(recentReleases.map(r => {
-      return {version: r.version, deps: r.deps}
-    }))
     recentReleases.every(release => {
       return release.deps &&
       release.deps.node.length &&


### PR DESCRIPTION
This will go green once https://github.com/electron/electron/issues/12006 has been fixed.